### PR TITLE
Use identical height for all asset cards

### DIFF
--- a/src/components/AssetCard.vue
+++ b/src/components/AssetCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card height="100%">
+  <v-card>
     <v-card-title primary-title>
       <div>
         <h3>{{cardData.name}}</h3>
@@ -15,7 +15,7 @@
       <object type="image/svg+xml" :data="cardData.preview" class="svgAsset"></object>
     </v-card-media>
     <v-card-media v-else-if="cardData.preview" :src="cardData.preview" height="200px" contain></v-card-media>
-    <v-chip :style="{visibility: cardData.fanmade ? 'visible' : 'hidden'}" color="accent" text-color="black">Fanmade Asset</v-chip>
+    <v-chip :class="{'hide-card': cardData.fanmade}" color="accent" text-color="black">Fanmade Asset</v-chip>
     <v-card-actions>
       <v-btn color="secondary" flat v-for="(downloadCardData,i) in cardData.formats" :key="i" :href="downloadCardData.link" target="_blank">
         {{downloadCardData.format}}
@@ -119,5 +119,9 @@ export default {
 
   .bottomPadding {
     padding: 0px 16px 16px 16px
+  }
+
+  .hide-card {
+    visibility: 'hidden'
   }
 </style>

--- a/src/components/AssetCard.vue
+++ b/src/components/AssetCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card>
+  <v-card height="100%">
     <v-card-title primary-title>
       <div>
         <h3>{{cardData.name}}</h3>
@@ -15,7 +15,7 @@
       <object type="image/svg+xml" :data="cardData.preview" class="svgAsset"></object>
     </v-card-media>
     <v-card-media v-else-if="cardData.preview" :src="cardData.preview" height="200px" contain></v-card-media>
-    <v-chip v-if="cardData.fanmade" color="accent" text-color="black">Fanmade Asset</v-chip>
+    <v-chip :style="{visibility: cardData.fanmade ? 'visible' : 'hidden'}" color="accent" text-color="black">Fanmade Asset</v-chip>
     <v-card-actions>
       <v-btn color="secondary" flat v-for="(downloadCardData,i) in cardData.formats" :key="i" :href="downloadCardData.link" target="_blank">
         {{downloadCardData.format}}


### PR DESCRIPTION
As told on Discord, here is a fix for the asset card not having the same height depending on the content.
Tested on Firefox & Edge.